### PR TITLE
Add ShareScreenButton and ShareCameraButton for janus adapter

### DIFF
--- a/public/janus.html
+++ b/public/janus.html
@@ -1,0 +1,124 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Realistic avatars — Networked-Aframe</title>
+    <meta name="description" content="Realistic avatars — Networked-Aframe" />
+
+    <!-- <script src="https://aframe.io/releases/1.5.0/aframe.min.js"></script> -->
+    <!-- aframe 1.5.0 has a warning for environment component, and an error for obb-collider hideCollider, so we're using a master build -->
+    <script src="https://cdn.jsdelivr.net/gh/aframevr/aframe@d6fa1c3890a15e05cf63a178ebf76d98d1e413f8/dist/aframe-master.min.js"></script>
+
+    <script src="https://cdn.jsdelivr.net/npm/networked-aframe@0.12.1/dist/networked-aframe.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/networked-aframe/naf-janus-adapter@3.2.0/dist/naf-janus-adapter.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/networked-aframe/naf-janus-adapter@3.2.0/examples/js/audio-system.js"></script>
+
+    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-extras@7.4.0/dist/aframe-extras.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/aframe-environment-component@1.3.4/dist/aframe-environment-component.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@fern-solutions/aframe-mirror@1.0.3/dist/mirror.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-cursor-teleport@1.5.0/dist/aframe-cursor-teleport-component.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/AdaRoseCannon/aframe-xr-boilerplate@f34468b9503d0c7326b9af0f1f09959004916875/simple-navmesh-constraint.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/c-frame/aframe-gltf-model-plus@9850e27/dist/gltf-model-plus.min.js"></script>
+
+    <script src="/dist/components.js"></script>
+    <script defer src="/dist/ui.js"></script>
+  </head>
+
+  <body>
+    <!--
+      For development with janus adapter:
+
+        adapter: janus
+        serverURL: wss://192.168.1.15:8081/janus;
+
+      You need to run `npm start dev2` to have https and go to https://192.168.1.15:8080
+    -->
+    <a-scene
+      renderer="physicallyCorrectLights:true;colorManagement:true"
+      networked-scene="
+        connectOnLoad: false;
+        room: forest;
+        debug: true;
+        adapter: janus;
+        serverURL: wss://192.168.1.15:8081/janus;
+    "
+      shadow="type: pcfsoft"
+      gltf-model="meshoptDecoderPath:https://unpkg.com/meshoptimizer@0.19.0/meshopt_decoder.js"
+      raycaster="far: 100; objects: [link];"
+      cursor="rayOrigin: mouse"
+    >
+      <a-assets>
+        <template id="avatar-template">
+          <a-entity player-info>
+            <a-entity class="model">
+              <!-- here we add a text component for a nametag; the value will be updated by the player-info component -->
+              <a-text class="nametag" align="center" value="?" position="0 2.1 0" scale=".5 .5 .5"></a-text>
+            </a-entity>
+            <a-entity class="camera" position="0 1.6 0" networked-audio-source></a-entity>
+          </a-entity>
+        </template>
+      </a-assets>
+
+      <a-entity id="scene">
+        <a-entity environment="preset:forest;shadow:true"></a-entity>
+        <a-entity light="type:ambient;intensity:0.5"></a-entity>
+        <a-mirror id="mirror" position="0 1.8 -3" scale="5 3 1" layers="0,3">
+          <a-box color="black" position="0 0 -0.02" scale="1.02 1.02 0.01"></a-box>
+        </a-mirror>
+        <a-plane
+          id="screenshare"
+          width="4.64"
+          height="2.64"
+          material="color: black"
+          position="6 2 6"
+          rotation="0 -90 0"
+          networked="template: #media-template; attachTemplateToLocal: false; networkId: screenshare; persistent: true; owner: scene"
+          video-texture-target
+          media-frame="bounds: 4.6 0.02 2.6; mediaType: all-2d"
+        ></a-plane>
+      </a-entity>
+
+      <a-entity
+        id="rig"
+        character-controller
+        cursor-teleport="cameraRig: #rig; cameraHead: #player; collisionEntities: .environmentGround; ignoreEntities: .clickable,[link]"
+        movement-controls="fly:false;controls: gamepad, trackpad, keyboard, nipple;"
+        spawn-in-circle="radius:1"
+        networked="template:#avatar-template;attachTemplateToLocal:false"
+        player-info
+      >
+        <a-entity id="player" class="camera" camera position="0 1.6 0" look-controls>
+          <a-box obb-collider visible="false" height="0.4" depth="0.4" width="0.4"></a-box>
+        </a-entity>
+      </a-entity>
+    </a-scene>
+    <script>
+      function genClientId() {
+        return String(crypto.getRandomValues(new Uint32Array(1))[0]);
+      }
+
+      // Prompt for audio.
+      document.addEventListener('DOMContentLoaded', () => {
+        const scene = document.querySelector('a-scene');
+        const micBtnEl = document.getElementById('mic-btn');
+
+        scene.addEventListener('adapter-ready', ({ detail: adapter }) => {
+          const clientId = genClientId();
+          adapter.setClientId(clientId);
+          navigator.mediaDevices
+            .getUserMedia({ audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true } })
+            .then((stream) => {
+              const audioSystem = scene.systems.audio;
+              audioSystem.addStreamToOutboundAudio('microphone', stream);
+              adapter.setLocalMediaStream(audioSystem.outboundStream).then(() => {
+                // adapter.enableMicrophone(state.micEnabled);
+              });
+            })
+            .catch((err) => {
+              console.warn('Microphone access not allowed. This client will not broadcast audio.');
+            });
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/src/ShareScreenButton.tsx
+++ b/src/ShareScreenButton.tsx
@@ -1,0 +1,287 @@
+/* global AFRAME NAF */
+import { Component, createMemo, createSignal, Show } from 'solid-js';
+import { TbScreenShare, TbScreenShareOff } from 'solid-icons/tb';
+import { BsCameraVideo, BsCameraVideoOff } from 'solid-icons/bs';
+
+const audioConstraints = {
+  echoCancellation: true,
+  noiseSuppression: true,
+  autoGainControl: true,
+};
+
+const showAlertDialog = (body: string, title: string) => {
+  console.error(body, title);
+};
+
+let currentVideoShareEntity: null | HTMLElement = null;
+let isHandlingVideoShare = false;
+
+interface VideoConstraints {
+  mediaSource?: string;
+  width?: {
+    max?: number;
+    ideal?: number;
+  };
+  height?: {
+    max?: number;
+    ideal?: number;
+  };
+  frameRate?: number;
+}
+
+interface AudioContraints {
+  echoCancellation: boolean;
+  noiseSuppression: boolean;
+  autoGainControl: boolean;
+}
+
+export const shareVideoMediaStream = async (
+  mediaFrameId: string,
+  constraints: { video: VideoConstraints; audio?: AudioContraints },
+  isDisplayMedia = false,
+) => {
+  // @ts-ignore
+  const scene = AFRAME.scenes[0];
+  const audioSystem = scene.systems.audio;
+  const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent); // may also be Chrome on iOS!
+  const title = isDisplayMedia ? 'Failed to share the screen' : 'Failed to share the camera';
+  if (
+    isDisplayMedia &&
+    (typeof navigator.mediaDevices === 'undefined' || typeof navigator.mediaDevices.getDisplayMedia === 'undefined')
+  ) {
+    // On Safari only, showAlert doesn't work here because we still have an active modal?
+    window.alert("Sorry, screen share doesn't work on mobile.");
+    return;
+  }
+  if (currentVideoShareEntity) {
+    await endVideoSharing();
+  }
+  if (isHandlingVideoShare) return;
+  isHandlingVideoShare = true;
+
+  let newStream;
+
+  try {
+    if (isDisplayMedia) {
+      newStream = await navigator.mediaDevices.getDisplayMedia(constraints);
+    } else {
+      newStream = await navigator.mediaDevices.getUserMedia(constraints);
+    }
+    // @ts-ignore
+  } catch (e: Error) {
+    if (e.name === 'NotAllowedError') {
+      let msg = 'Please verify sharing the screen or camera is allowed in the permissions.';
+      if (!isSafari) {
+        msg += ' Click on the lock icon in the url bar to see the allowed permissions.';
+      }
+      // @ts-ignore
+      if (AFRAME.utils.device.isMobile()) {
+        if (isDisplayMedia) {
+          showAlertDialog("Sorry, screen share doesn't work on mobile.", title);
+        } else {
+          showAlertDialog(msg, title);
+        }
+      } else {
+        if (e.message === 'Permission denied by system') {
+          showAlertDialog(
+            'The browser returned the following error: Permission denied by system. Are you using Chrome on macOS? Sharing a Chrome tab should work. If you want to share your screen or a window, please go to System Preferences > Security & Privacy > Privacy > Camera & Microphone, and make sure Chrome is listed and has a checkbox.',
+            title,
+          );
+        } else {
+          showAlertDialog(msg, title);
+        }
+      }
+    } else {
+      console.error(e);
+      showAlertDialog(
+        'The browser returned the following error: ' + e.name + ': ' + e.message,
+        'Failed to share the screen or camera',
+      );
+    }
+    isHandlingVideoShare = false;
+    scene.emit('share_video_failed');
+    return;
+  }
+
+  // @ts-ignore
+  const mediaStream = audioSystem.outboundStream;
+  const videoTracks = newStream ? newStream.getVideoTracks() : [];
+  if (videoTracks.length > 0) {
+    videoTracks.forEach((track) => {
+      mediaStream.addTrack(track);
+      track.onended = () => {
+        scene.emit('action_end_video_sharing');
+      };
+    });
+
+    if (newStream && newStream.getAudioTracks().length > 0) {
+      // @ts-ignore
+      audioSystem.addStreamToOutboundAudio('screenshare', newStream);
+    }
+
+    // @ts-ignore
+    await NAF.connection.adapter?.setLocalMediaStream(mediaStream);
+    const mediaFrameSystem = scene.systems['media-frame'];
+    // @ts-ignore
+    currentVideoShareEntity = mediaFrameSystem.getMediaFrameById(mediaFrameId);
+
+    if (currentVideoShareEntity) {
+      // @ts-ignore
+      currentVideoShareEntity.setAttribute('video-texture-target', {
+        src: `naf://clients/${NAF.clientId}/video`,
+      });
+    }
+
+    scene.emit('share_video_enabled', {
+      source: isDisplayMedia ? 'screen' : 'camera',
+      mediaFrameId: mediaFrameId,
+    });
+  } else {
+    scene.emit('share_video_failed', { message: 'No video track' });
+  }
+
+  isHandlingVideoShare = false;
+};
+
+export const shareCamera = (mediaFrameId: string) => {
+  // @ts-ignore
+  const constraints = {
+    video: {
+      mediaSource: 'camera',
+      width: { max: 1280, ideal: 640 },
+      height: { ideal: 360 },
+      frameRate: 30,
+    },
+  };
+  shareVideoMediaStream(mediaFrameId, constraints);
+};
+
+export const shareScreen = (mediaFrameId: string) => {
+  // @ts-ignore
+  const constraints = {
+    video: {
+      width: { max: 1600 },
+      height: { max: 900 },
+    },
+    audio: audioConstraints,
+  };
+  shareVideoMediaStream(mediaFrameId, constraints, true);
+};
+
+export const endVideoSharing = async () => {
+  if (isHandlingVideoShare) return;
+  isHandlingVideoShare = true;
+
+  // @ts-ignore
+  const scene = AFRAME.scenes[0];
+  const audioSystem = scene.systems.audio;
+  // @ts-ignore
+  const mediaStream = audioSystem.outboundStream;
+  for (const track of mediaStream.getVideoTracks()) {
+    track.onended = null;
+    track.stop(); // Stop video track to remove the "Stop screen sharing" bar right away.
+    // For tab sharing with audio, the audio track also needs to be stopped, this is done audioSystem.removeStreamFromOutboundAudio
+    mediaStream.removeTrack(track);
+  }
+
+  // @ts-ignore
+  audioSystem.removeStreamFromOutboundAudio('screenshare');
+
+  // @ts-ignore
+  await NAF.connection.adapter?.setLocalMediaStream(mediaStream);
+  currentVideoShareEntity = null;
+
+  scene.emit('share_video_disabled');
+  isHandlingVideoShare = false;
+};
+
+export const [shareScreenIconEnabled, setShareScreenIconEnabled] = createSignal(false);
+export const [shareCameraIconEnabled, setShareCameraIconEnabled] = createSignal(false);
+
+export const ShareScreenButton: Component = () => {
+  const title = createMemo(() => {
+    if (!shareScreenIconEnabled()) {
+      return 'Share screen';
+    } else {
+      return 'Stop sharing screen';
+    }
+  });
+
+  return (
+    <button
+      class="btn-rounded btn-secondary"
+      classList={{ active: shareScreenIconEnabled() }}
+      onClick={() => {
+        const enabled = shareScreenIconEnabled();
+        if (enabled) {
+          // @ts-ignore
+          endVideoSharing();
+        } else {
+          // @ts-ignore
+          const mediaFrameSystem = AFRAME.scenes[0].systems['media-frame'];
+          // @ts-ignore
+          const mediaFrame = mediaFrameSystem.getClosestMediaFrame('video');
+          if (mediaFrame) {
+            shareScreen(mediaFrame.id);
+          } else {
+            // TODO spawn a plane
+          }
+        }
+        // @ts-ignore
+        document.activeElement.blur();
+        document.body.focus();
+      }}
+      title={title()}
+    >
+      <Show when={shareScreenIconEnabled()}>
+        <TbScreenShare size={24} />
+      </Show>
+      <Show when={!shareScreenIconEnabled()}>
+        <TbScreenShareOff size={24} />
+      </Show>
+    </button>
+  );
+};
+
+export const ShareCameraButton: Component = () => {
+  const title = createMemo(() => {
+    if (!shareCameraIconEnabled()) {
+      return 'Share camera';
+    } else {
+      return 'Stop sharing camera';
+    }
+  });
+
+  return (
+    <button
+      class="btn-rounded btn-secondary"
+      classList={{ active: shareCameraIconEnabled() }}
+      onClick={() => {
+        const enabled = shareCameraIconEnabled();
+        if (enabled) {
+          // @ts-ignore
+          endVideoSharing();
+        } else {
+          // @ts-ignore
+          const mediaFrameSystem = AFRAME.scenes[0].systems['media-frame'];
+          // @ts-ignore
+          const mediaFrame = mediaFrameSystem.getClosestMediaFrame();
+          if (mediaFrame) {
+            shareCamera(mediaFrame.id);
+          }
+        }
+        // @ts-ignore
+        document.activeElement.blur();
+        document.body.focus();
+      }}
+      title={title()}
+    >
+      <Show when={shareCameraIconEnabled()}>
+        <BsCameraVideo size={24} />
+      </Show>
+      <Show when={!shareCameraIconEnabled()}>
+        <BsCameraVideoOff size={24} />
+      </Show>
+    </button>
+  );
+};

--- a/src/systems/video.js
+++ b/src/systems/video.js
@@ -1,0 +1,75 @@
+/* global AFRAME */
+import {
+  shareCamera,
+  shareScreen,
+  setShareCameraIconEnabled,
+  setShareScreenIconEnabled,
+  endVideoSharing,
+} from '../ShareScreenButton';
+
+function eventsBind(component, events) {
+  for (const eventName in events) {
+    component.events[eventName] = events[eventName].bind(component);
+  }
+}
+
+AFRAME.registerSystem('video', {
+  init() {
+    eventsBind(this, this.events);
+    this.eventsAttach();
+  },
+
+  /**
+   * Attach events from component-defined events map.
+   */
+  eventsAttach: function () {
+    // Safety detach to prevent double-registration.
+    this.eventsDetach();
+    for (const eventName in this.events) {
+      this.el.addEventListener(eventName, this.events[eventName]);
+    }
+  },
+
+  /**
+   * Detach events from component-defined events map.
+   */
+  eventsDetach: function () {
+    for (const eventName in this.events) {
+      this.el.removeEventListener(eventName, this.events[eventName]);
+    }
+  },
+
+  events: {
+    action_share_camera: (evt) => {
+      const mediaFrameId = evt.detail.el.id;
+      shareCamera(mediaFrameId);
+    },
+    action_share_screen: (evt) => {
+      const mediaFrameId = evt.detail.el.id;
+      shareScreen(mediaFrameId);
+    },
+    action_end_video_sharing: endVideoSharing,
+    // @ts-ignore
+    share_video_enabled: (evt) => {
+      console.log('share video enabled', evt);
+      if (evt.detail.source === 'camera') {
+        setShareCameraIconEnabled(true);
+      }
+      if (evt.detail.source === 'screen') {
+        setShareScreenIconEnabled(true);
+      }
+    },
+    share_video_disabled: () => {
+      setShareCameraIconEnabled(false);
+      setShareScreenIconEnabled(false);
+    },
+    share_video_failed: () => {},
+  },
+  play() {
+    // This is never executed
+  },
+  pause() {
+    // This is never executed
+    // There is no way to properly remove listeners when removing the system or scene
+  },
+});

--- a/src/ui.tsx
+++ b/src/ui.tsx
@@ -3,10 +3,12 @@ import { render } from 'solid-js/web';
 import { Show, createEffect, createResource, createSignal, onMount } from 'solid-js';
 import { IoSettingsOutline } from 'solid-icons/io';
 import { Avatar, AvatarSelect, defaultOutfits, setGender, setOutfit } from './AvatarSelect';
-import { MicButton } from './MicButton';
+import { MicButton, nafAdapter } from './MicButton';
 import { UsernameInput } from './UsernameInput';
 import { ChatButton } from './Chat';
 import { UsersButton } from './UsersButton';
+import { ShareCameraButton, ShareScreenButton } from './ShareScreenButton';
+import './systems/video';
 import { uiSettings } from './config';
 
 const [showSettings, setShowSettings] = createSignal(false);
@@ -141,6 +143,10 @@ const BottomBarCenter = () => {
         <IoSettingsOutline size={24} />
       </button>
       <MicButton entity="#rig" />
+      <Show when={nafAdapter() === 'janus'}>
+        <ShareCameraButton />
+        <ShareScreenButton />
+      </Show>
       <UsersButton />
       <ChatButton />
     </div>


### PR DESCRIPTION
This is my ShareScreenButton, ShareCameraButton and video system I use with janus adapter.
For now I duplicated index.html to janus.html, you can compare easily the two files.
The example uses video-texture-target and media-frame components from gltf-model-plus, see https://github.com/c-frame/aframe-gltf-model-plus/issues/16

More work to be done to be compatible with easyrtc adapter.